### PR TITLE
build shared libraries (and nngcat executable) instead of static library

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,7 @@ if errorlevel 1 exit 1
 
 :: Configure 
 cmake -G "Ninja" -B "build" -S . ^
+         -DBUILD_SHARED_LIBS=ON ^
          -DCMAKE_BUILD_TYPE=Release ^
          -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
          -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ if [[ "$target_platform" == osx-arm64 ]]; then
 	cmake -B build -S . \
 		${CMAKE_ARGS} \
                 -G Ninja \
+                -DBUILD_SHARED_LIBS=ON \
                 -DNNG_ENABLE_TLS=ON \
 		-DCMAKE_INSTALL_PREFIX=$PREFIX \
 		-DCMAKE_INSTALL_LIBDIR=lib \
@@ -16,6 +17,7 @@ else
 	cmake -B build -S . \
 		${CMAKE_ARGS} \
                 -G Ninja \
+                -DBUILD_SHARED_LIBS=ON \
                 -DNNG_ENABLE_TLS=ON \
 		-DCMAKE_INSTALL_PREFIX=$PREFIX \
 		-DCMAKE_INSTALL_LIBDIR=lib \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,8 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libnng.so  # [unix]
+    - test -f $PREFIX/lib/libnng.so  # [linux]
+    - test -f $PREFIX/lib/libnng.dylib  # [osx]
 
 about:
   home: https://nng.nanomsg.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ test:
   commands:
     - test -f $PREFIX/lib/libnng.so  # [linux]
     - test -f $PREFIX/lib/libnng.dylib  # [osx]
+    - nngcat -V  # [unix]
+    - nngcat.exe -V  # [win]
 
 about:
   home: https://nng.nanomsg.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - test.patch  # [linux]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -25,10 +25,11 @@ requirements:
     - mbedtls  # [not win]
   run:
     - ucrt  # [win]
+    - mbedtls #[not win]
 
 test:
   commands:
-    - test -f $PREFIX/lib/libnng.a  # [unix]
+    - test -f $PREFIX/lib/libnng.so  # [unix]
 
 about:
   home: https://nng.nanomsg.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - mbedtls  # [not win]
   run:
     - ucrt  # [win]
-    - mbedtls #[not win]
+    - mbedtls  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Tested on my linux box, let's see if it works on the others...

This PR will break any package currently relying on the presence of the static library.  I'm not sure if any such package exists.  The guidance in [CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md) is that, if the static library is really required, it should be in a separate package called `nng-static`.